### PR TITLE
change type raw memory is stored in to unsigned

### DIFF
--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -219,7 +219,7 @@ static std::string psolualib_read_wstr(int memory_address, int len) {
 
 static sol::table psolualib_read_mem(sol::table t, int memory_address, int len) {
 	sol::state_view lua(g_LuaState);
-	char buf[8192];
+	unsigned char buf[8192];
 	memset(buf, 0, len);
 	SIZE_T read;
 	auto pid = GetCurrentProcess();


### PR DESCRIPTION
should address some issues people are having with the dropchecker
0x00AA00 for SoF is showing up as 0x00AAFF

```
>>> struct.pack("i", 170*2**16)
'\x00\x00\xaa\x00'
>>> struct.pack("i", -86*2**16)
'\x00\x00\xaa\xff'
```