### PR TITLE
Efficiently read sections of memory into a lua string

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,6 @@ PSO specific functions are in the `pso` global table.
  * read_cstr(addr, len) -- read c_str at address with len bytes, or null terminated (0 len)
  * read_wstr(addr, len) -- read utf16 str to utf8 at address with len characters, or double null terminated (0 len)
  * read_mem(table, addr, len) -- read len bytes from addr into table. the table should be initialized as empty, i.e. `local table = {}; pso.read_mem(table, 0x00400000, 0x7fffffff-0x00400000)` (don't read the entire address space, that's silly and will probably kill the process)
+ * read_mem_str(addr, len) -- read len bytes from addr into a string (not null terminated). lua treats binary files the same way it does text files so this can be used to efficiently write sections of memory directly to a file.
  * reload() -- at the end of present, re-initialize the lua state. all addons and modules will be reloaded, no state will be preserved.
  * base_address -- the base address of the PSOBB process

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -13,6 +13,7 @@ static int psolua_print(lua_State *L);
 static std::string psolualib_read_cstr(int memory_address, int len = 2048);
 static std::string psolualib_read_wstr(int memory_address, int len = 1024);
 static sol::table psolualib_read_mem(sol::table t, int memory_address, int len);
+static std::string psolualib_read_mem_str(int memory_address, int len = 2048);
 static sol::table psolualib_list_addons();
 
 bool psolua_initialize_on_next_frame = false;
@@ -114,6 +115,7 @@ void psolua_load_library(lua_State * L) {
     psoTable["read_cstr"] = psolualib_read_cstr;
     psoTable["read_wstr"] = psolualib_read_wstr;
     psoTable["read_mem"] = psolualib_read_mem;
+    psoTable["read_mem_str"] = psolualib_read_mem_str;
     psoTable["set_sleep_hack_enabled"] = psolualib_set_sleep_hack_enabled;
     psoTable["base_address"] = g_PSOBaseAddress;
     psoTable["list_addon_directories"] = psolualib_list_addons;
@@ -205,6 +207,17 @@ static sol::table psolualib_read_mem(sol::table t, int memory_address, int len) 
         t.add((int)buf[i]);
     }
     return t;
+}
+
+static std::string psolualib_read_mem_str(int memory_address, int len) {
+    char buf[8192];
+    memset(buf, 0, len);
+    SIZE_T read;
+    auto pid = GetCurrentProcess();
+    if (!ReadProcessMemory(pid, (LPCVOID)memory_address, buf, len, &read)) {
+        throw "ReadProcessMemory error";
+    }
+    return std::string(buf, len);
 }
 
 static sol::table psolualib_list_addons() {


### PR DESCRIPTION
For a lot of my addon development, I found it most efficient to create a simple addon where I could take snapshots of sections of memory with the press of a button and analyze them in another program. However, I found the performance of read_mem() to be prohibitive when attempting to write a large memory snapshot to a file because I had to convert each individual byte into a char and write them individually to the file. This function allows me to read entire sections of memory into a string and simply write it all out to a file at once. With this, I've found it's actually possible to dump the entire memory space to a file in a little less than 10 seconds.

For reference, I've attached the init.lua script for the addon I've been using to grab memory snapshots: [Memsnap addon](https://github.com/HybridEidolon/psobbaddonplugin/files/995048/init.txt)
