### PR TITLE
Fix psolualib_read_wstr() for Windows XP

### DIFF
--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -185,7 +185,7 @@ static std::string psolualib_read_wstr(int memory_address, int len) {
     if (!ReadProcessMemory(pid, (LPCVOID)memory_address, buf, len * 2, &read)) {
         throw "ReadProcessMemory error";
     }
-    if (!WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, (LPCWCH)buf, len, buf2, 8192, nullptr, nullptr)) {
+    if (!WideCharToMultiByte(CP_UTF8, 0, (LPCWCH)buf, len, buf2, 8192, nullptr, nullptr)) {
         throw "invalid utf-16 string";
     }
     return buf2;


### PR DESCRIPTION
It seems the WC_ERR_INVALID_CHARS flag that is passed into the WideCharToMultiByte() function is only valid for Windows Vista or later and will actually cause the function to fail on Windows XP. This change simply removes the flag.