### PR TITLE
Custom theme and warning fixes

### DIFF
--- a/bbmod.sln
+++ b/bbmod.sln
@@ -1,25 +1,28 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bbmod", "bbmod\bbmod.vcxproj", "{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Debug|x64.ActiveCfg = Debug|Win32
+		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Debug|x64.Build.0 = Debug|Win32
 		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Debug|x86.ActiveCfg = Debug|Win32
 		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Debug|x86.Build.0 = Debug|Win32
+		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Release|x64.ActiveCfg = Release|x64
+		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Release|x64.Build.0 = Release|x64
 		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Release|x86.ActiveCfg = Release|Win32
 		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {978F69CC-E1E9-4E55-8F53-D277C4FCE4FD}
 	EndGlobalSection
 EndGlobal

--- a/bbmod.sln
+++ b/bbmod.sln
@@ -1,28 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bbmod", "bbmod\bbmod.vcxproj", "{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Debug|x64.ActiveCfg = Debug|Win32
-		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Debug|x64.Build.0 = Debug|Win32
 		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Debug|x86.ActiveCfg = Debug|Win32
 		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Debug|x86.Build.0 = Debug|Win32
-		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Release|x64.ActiveCfg = Release|x64
-		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Release|x64.Build.0 = Release|x64
 		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Release|x86.ActiveCfg = Release|Win32
 		{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {978F69CC-E1E9-4E55-8F53-D277C4FCE4FD}
 	EndGlobalSection
 EndGlobal

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -58,8 +58,8 @@
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
-      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
+      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib;winmm.lib</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -75,8 +75,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
-      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
+      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib;winmm.lib</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}</ProjectGuid>
     <RootNamespace>bbmod</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -9,14 +9,6 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}</ProjectGuid>
@@ -37,19 +29,6 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -61,26 +40,12 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>dinput8</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>dinput8</TargetName>
-    <TargetExt>.dll</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <TargetName>dinput8</TargetName>
-    <TargetExt>.dll</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>dinput8</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
@@ -95,18 +60,6 @@
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
       <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <Link>
-      <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -124,22 +77,6 @@
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
       <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -9,23 +9,44 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}</ProjectGuid>
     <RootNamespace>bbmod</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -40,12 +61,26 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>dinput8</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>dinput8</TargetName>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>dinput8</TargetName>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>dinput8</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
@@ -58,8 +93,19 @@
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
-      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
+      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
+      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -75,8 +121,23 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
-      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
+      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
+      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -62,6 +62,18 @@
       <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
+      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -77,6 +89,22 @@
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
       <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib;winmm.lib</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
+      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}</ProjectGuid>
@@ -29,6 +37,19 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -40,12 +61,26 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>dinput8</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>dinput8</TargetName>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>dinput8</TargetName>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>dinput8</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
@@ -58,7 +93,7 @@
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib;winmm.lib</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
@@ -87,7 +122,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib;winmm.lib</AdditionalDependencies>
+      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib;winmm.lib</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -9,14 +9,6 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}</ProjectGuid>
@@ -37,19 +29,6 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -61,26 +40,12 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>dinput8</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>dinput8</TargetName>
-    <TargetExt>.dll</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <TargetName>dinput8</TargetName>
-    <TargetExt>.dll</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetName>dinput8</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
@@ -93,19 +58,8 @@
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <Link>
-      <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -121,23 +75,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -21,32 +21,32 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A822A2F2-38F1-43B1-ACCD-3DBBD3F66C1B}</ProjectGuid>
     <RootNamespace>bbmod</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -93,7 +93,8 @@
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -121,7 +122,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>dinput8.def</ModuleDefinitionFile>
-      <AdditionalDependencies>advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+      <AdditionalDependencies>dxguid.lib;advapi32.lib;$(SolutionDir)libs\libMinHook-x86-v140-mtd.lib;$(SolutionDir)libs\lua51.lib</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>libcmt;libcmtd;</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/bbmod/src/dinput8.cpp
+++ b/bbmod/src/dinput8.cpp
@@ -1,4 +1,4 @@
-﻿#include <iostream>
+#include <iostream>
 #include <fstream>
 #include <string>
 
@@ -125,7 +125,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 }
 
 HRESULT WINAPI DirectInput8Create(HINSTANCE inst_handle, DWORD version, const IID& r_iid, LPVOID* out_wrapper, LPUNKNOWN p_unk) {
-    if (r_iid == IID_IDirectInput8A) {
+    GUID aguid = {
+        3212410928, 18490, 19874,{ 170, 153, 93, 100, 237, 54, 151, 0 }
+    };
+
+    if (r_iid == aguid) {
         if (!dinput8AModule) {
             auto ret = oDirectInput8Create(inst_handle, version, r_iid, out_wrapper, p_unk);
             if (ret) {

--- a/bbmod/src/dinput8.cpp
+++ b/bbmod/src/dinput8.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <Windows.h>
+#define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 
 //#include "physfs.h"
@@ -124,11 +125,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 }
 
 HRESULT WINAPI DirectInput8Create(HINSTANCE inst_handle, DWORD version, const IID& r_iid, LPVOID* out_wrapper, LPUNKNOWN p_unk) {
-    GUID aguid = {
-        3212410928, 18490, 19874, { 170, 153, 93, 100, 237, 54, 151, 0 }
-    };
-
-    if (r_iid == aguid) {
+    if (r_iid == IID_IDirectInput8A) {
         if (!dinput8AModule) {
             auto ret = oDirectInput8Create(inst_handle, version, r_iid, out_wrapper, p_unk);
             if (ret) {

--- a/bbmod/src/imgui_dinput8_dev.h
+++ b/bbmod/src/imgui_dinput8_dev.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 
 class ImguiDInput : IDirectInput8A {

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -1,4 +1,4 @@
-﻿#include "lua_psolib.h"
+#include "lua_psolib.h"
 
 #include <Windows.h>
 #include "sol.hpp"
@@ -178,6 +178,8 @@ void psolua_initialize_state(void) {
     psoluah_Init();
 
     psolua_initialize_on_next_frame = false;
+
+    loadCustomTheme();
 }
 
 static std::string psolualib_read_cstr(int memory_address, int len) {
@@ -255,4 +257,127 @@ static sol::table psolualib_list_addons() {
     } while (FindNextFileA(hFind, &find));
 
     return ret;
+}
+
+wchar_t *themeElements[ImGuiCol_COUNT]
+{
+    L"Text",
+    L"TextDisabled",
+    L"WindowBg",
+    L"ChildWindowBg",
+    L"PopupBg",
+    L"Border",
+    L"BorderShadow",
+    L"FrameBg",
+    L"FrameBgHovered",
+    L"FrameBgActive",
+    L"TitleBg",
+    L"TitleBgCollapsed",
+    L"TitleBgActive",
+    L"MenuBarBg",
+    L"ScrollbarBg",
+    L"ScrollbarGrab",
+    L"ScrollbarGrabHovered",
+    L"ScrollbarGrabActive",
+    L"ComboBg",
+    L"CheckMark",
+    L"SliderGrab",
+    L"SliderGrabActive",
+    L"Button",
+    L"ButtonHovered",
+    L"ButtonActive",
+    L"Header",
+    L"HeaderHovered",
+    L"HeaderActive",
+    L"Column",
+    L"ColumnHovered",
+    L"ColumnActive",
+    L"ResizeGrip",
+    L"ResizeGripHovered",
+    L"ResizeGripActive",
+    L"CloseButton",
+    L"CloseButtonHovered",
+    L"CloseButtonActive",
+    L"PlotLines",
+    L"PlotLinesHovered",
+    L"PlotHistogram",
+    L"PlotHistogramHovered",
+    L"TextSelectedBg",
+    L"ModalWindowDarkening",
+};
+
+void loadCustomTheme()
+{
+    int ret;
+    int i;
+    float s = 1.0f / 255.0f;
+    FILE *fp;
+
+    wchar_t *themeFile = L"addons\\theme.ini";
+
+    _wfopen_s(&fp, themeFile, L"r");
+    if (fp == NULL)
+    {
+        const ImGuiStyle default_style;
+
+        ImGuiStyle& style = ImGui::GetStyle();
+
+        style.Alpha = default_style.Alpha;
+        style.FrameRounding = default_style.FrameRounding;
+        for (i = 0; i < ImGuiCol_COUNT; i++)
+        {
+            style.Colors[i] = default_style.Colors[i];
+        }
+    }
+    else
+    {
+        // GetPrivateProfile* functions require absolute path to the file 
+        // it will be reading from to be able to read from the application's directory
+        wchar_t lpAppName[128] = { 0 };
+        wchar_t lpKeyName[128] = { 0 };
+        wchar_t lpDefault[128] = { 0 };
+        wchar_t lpReturnedString[256] = { 0 };
+        wchar_t lpFileName[MAX_PATH] = { 0 };
+        wchar_t lpBuffer[MAX_PATH] = { 0 };
+
+        fclose(fp);
+
+        GetCurrentDirectoryW(_countof(lpBuffer), lpBuffer);
+        wcscat_s(lpFileName, _countof(lpFileName), lpBuffer);
+        wcscat_s(lpFileName, _countof(lpFileName), L"\\");
+        wcscat_s(lpFileName, _countof(lpFileName), themeFile);
+
+        wcscpy_s(lpAppName, _countof(lpAppName), L"IMGUI_THEME");
+
+        ImGuiStyle& style = ImGui::GetStyle();
+
+        swprintf_s(lpKeyName, _countof(lpKeyName), L"Alpha");
+        ret = GetPrivateProfileStringW(lpAppName, lpKeyName, lpDefault, lpReturnedString, _countof(lpReturnedString), lpFileName);
+        if (ret != 0)
+        {
+            style.Alpha = wcstof(lpReturnedString, NULL);
+        }
+
+        swprintf_s(lpKeyName, _countof(lpKeyName), L"FrameRounding");
+        ret = GetPrivateProfileStringW(lpAppName, lpKeyName, lpDefault, lpReturnedString, _countof(lpReturnedString), lpFileName);
+        if (ret != 0)
+        {
+            style.FrameRounding = wcstof(lpReturnedString, NULL);
+        }
+
+        for (i = 0; i < ImGuiCol_COUNT; i++)
+        {
+            swprintf_s(lpKeyName, _countof(lpKeyName), themeElements[i]);
+            ret = GetPrivateProfileStringW(lpAppName, lpKeyName, lpDefault, lpReturnedString, _countof(lpReturnedString), lpFileName);
+            if (ret != 0)
+            {
+                unsigned int color = wcstoul(lpReturnedString, NULL, 16);
+                style.Colors[i] = ImVec4(
+                    ((color >> 16) & 0xFF) * s,
+                    ((color >>  8) & 0xFF) * s,
+                    ((color >>  0) & 0xFF) * s,
+                    ((color >> 24) & 0xFF) * s);
+            }
+        }
+    }
 }

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -323,7 +323,6 @@ void loadCustomTheme()
         ImGuiStyle& style = ImGui::GetStyle();
 
         style.Alpha = default_style.Alpha;
-        style.FrameRounding = default_style.FrameRounding;
         for (i = 0; i < ImGuiCol_COUNT; i++)
         {
             style.Colors[i] = default_style.Colors[i];

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -349,38 +349,22 @@ void loadCustomTheme()
     wcscpy_s(lpAppName, _countof(lpAppName), L"ImGuiStyle");
 
     // Theme stuff
-    swprintf_s(lpKeyName, _countof(lpKeyName), L"UseCustomTheme");
-    ret = GetPrivateProfileIntW(lpAppName, lpKeyName, -1, lpFileName);
-    if (ret == 1)
-    {
-        swprintf_s(lpKeyName, _countof(lpKeyName), L"Alpha");
-        ret = GetPrivateProfileStringW(lpAppName, lpKeyName, lpDefault, lpReturnedString, _countof(lpReturnedString), lpFileName);
-        if (ret != 0)
-        {
-            style.Alpha = wcstof(lpReturnedString, NULL);
-        }
-
-        for (i = 0; i < ImGuiCol_COUNT; i++)
-        {
-            swprintf_s(lpKeyName, _countof(lpKeyName), themeElements[i]);
-            ret = GetPrivateProfileStringW(lpAppName, lpKeyName, lpDefault, lpReturnedString, _countof(lpReturnedString), lpFileName);
-            if (ret != 0)
-            {
-                unsigned int color = wcstoul(lpReturnedString, NULL, 16);
-                style.Colors[i] = ImVec4(
-                    ((color >> 16) & 0xFF) * s,
-                    ((color >> 8) & 0xFF) * s,
-                    ((color >> 0) & 0xFF) * s,
-                    ((color >> 24) & 0xFF) * s);
-            }
-        }
+    swprintf_s(lpKeyName, _countof(lpKeyName), L"Alpha");
+    ret = GetPrivateProfileStringW(lpAppName, lpKeyName, lpDefault, lpReturnedString, _countof(lpReturnedString), lpFileName);
+    if (ret != 0) {
+        style.Alpha = wcstof(lpReturnedString, NULL);
     }
-    else
-    {
-        style.Alpha = default_style.Alpha;
-        for (i = 0; i < ImGuiCol_COUNT; i++)
-        {
-            style.Colors[i] = default_style.Colors[i];
+
+    for (i = 0; i < ImGuiCol_COUNT; i++) {
+        swprintf_s(lpKeyName, _countof(lpKeyName), themeElements[i]);
+        ret = GetPrivateProfileStringW(lpAppName, lpKeyName, lpDefault, lpReturnedString, _countof(lpReturnedString), lpFileName);
+        if (ret != 0) {
+            unsigned int color = wcstoul(lpReturnedString, NULL, 16);
+            style.Colors[i] = ImVec4(
+                ((color >> 16) & 0xFF) * s,
+                ((color >> 8) & 0xFF) * s,
+                ((color >> 0) & 0xFF) * s,
+                ((color >> 24) & 0xFF) * s);
         }
     }
 }

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -358,13 +358,6 @@ void loadCustomTheme()
             style.Alpha = wcstof(lpReturnedString, NULL);
         }
 
-        swprintf_s(lpKeyName, _countof(lpKeyName), L"FrameRounding");
-        ret = GetPrivateProfileStringW(lpAppName, lpKeyName, lpDefault, lpReturnedString, _countof(lpReturnedString), lpFileName);
-        if (ret != 0)
-        {
-            style.FrameRounding = wcstof(lpReturnedString, NULL);
-        }
-
         for (i = 0; i < ImGuiCol_COUNT; i++)
         {
             swprintf_s(lpKeyName, _countof(lpKeyName), themeElements[i]);

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -354,6 +354,10 @@ void loadCustomTheme()
     if (ret != 0) {
         style.Alpha = wcstof(lpReturnedString, NULL);
     }
+    else
+    {
+        style.Alpha = default_style.Alpha;
+    }
 
     for (i = 0; i < ImGuiCol_COUNT; i++) {
         swprintf_s(lpKeyName, _countof(lpKeyName), themeElements[i]);
@@ -365,6 +369,10 @@ void loadCustomTheme()
                 ((color >> 8) & 0xFF) * s,
                 ((color >> 0) & 0xFF) * s,
                 ((color >> 24) & 0xFF) * s);
+        }
+        else
+        {
+            style.Colors[i] = default_style.Colors[i];
         }
     }
 }

--- a/bbmod/src/lua_psolib.h
+++ b/bbmod/src/lua_psolib.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <Windows.h>
 #include <string>
@@ -19,3 +19,5 @@ struct FPUSTATE {
 
 void psolua_store_fpu_state(struct FPUSTATE& fpustate);
 void psolua_restore_fpu_state(struct FPUSTATE& fpustate);
+
+void loadCustomTheme();


### PR DESCRIPTION
The main thing in the PR is the custom theme being loaded from an ini file and reset to default if the file is not present or the theme is disabled in the ini file.
The default theme file can be found [here](https://gist.github.com/Solybum/50f37b990514f291ef76e09490b204bb)

Also the PR has
- 2 DIRECTINPUT_VERSION defines to avoid the warning about it not being present.
- IID_IDirectInput8A from dxguid.lib
- Updated platform toolset and version to VS2017 (I don't know if everyone will want this tho)
